### PR TITLE
Fix TypeError

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = (
                 where: {},
                 offset: +req.body.start || 0,
                 limit: Math.min(Math.max(+req.body.length || 0, 0), limit),
-                order: req.body.order.map(({column, dir}) => [req.body.columns[+column].data, dir]),
+                order: (req.body.order || []).map(({column, dir}) => [req.body.columns[+column].data, dir]),
             });
             res.json({
                 draw: +req.body.draw || 0,


### PR DESCRIPTION
When I was loading the interface I kept getting the error below at this line. I added a default value and that has fixed the error for me.

```
TypeError: Cannot read property 'map' of undefined
```